### PR TITLE
Avoid two pair tracks sound at the same time

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -113,17 +113,24 @@
         
         $(this).attr('uniq-id', uniqueId);
 
-        play_pause_button.on('click', function() {
+        play_pause_button.on('click', function(e) {
+
+          const $target = $(e.currentTarget);
+          play_pause_button.toggleClass("isPlaying");
+          
           wavesurfer.playPause();
 
-          const pairPlayPause = play_pause_button.parent('.player-container').siblings('.player-container').find('.playPause');
-          
-          // If other pair is playing, pause it
-          if (pairPlayPause.hasClass('isPlaying')) {
-            pauseSiblingAudio(pairPlayPause);
+          const isPlaying = $('.isPlaying');
+
+          if (isPlaying.length === 1) {
+            return;
           }
 
-          play_pause_button.toggleClass("isPlaying");
+          $('.isPlaying').each(function() {
+            if (!$target.is($(this))) {
+              pauseSiblingAudio($(this));
+            } 
+          })
         });
 
         const pauseSiblingAudio = (play_pause_button) => {

--- a/templates/index.html
+++ b/templates/index.html
@@ -86,6 +86,7 @@
         send_answers();
       });
 
+      const waveSurfers = new Map();
 
       // player stuff
       $(".waveform").each(function(){
@@ -100,11 +101,41 @@
           backend: 'MediaElement'
         });
 
+        let uniqueId = Date.now();
+        // Store the Surfer object using an unique id along with its track name as a key
+        // UniqueId is needed because sometimes same track can appear twice (or more) on the same page. So we prevent
+        // start playing different pairs.
+
+        waveSurfers.set(uniqueId + '_' + track_name, wavesurfer);
+
         // add play pause feature
         var play_pause_button = $(this).parent().children('.playPause');
+        
+        $(this).attr('uniq-id', uniqueId);
+
         play_pause_button.on('click', function() {
           wavesurfer.playPause();
+
+          const pairPlayPause = play_pause_button.parent('.player-container').siblings('.player-container').find('.playPause');
+          
+          // If other pair is playing, pause it
+          if (pairPlayPause.hasClass('isPlaying')) {
+            pauseSiblingAudio(pairPlayPause);
+          }
+
+          play_pause_button.toggleClass("isPlaying");
         });
+
+        const pauseSiblingAudio = (play_pause_button) => {
+
+          const waveformSibling = play_pause_button.siblings('.waveform');
+          const uniqueId = waveformSibling.attr('uniq-id');
+          const trackPath = waveformSibling.attr('track-path');
+        
+          const siblingWavesurfer = waveSurfers.get(uniqueId + '_' + trackPath);
+
+          siblingWavesurfer.playPause();
+        }
 
         // Toggle play/pause text
         wavesurfer.on('play', function() {
@@ -113,6 +144,7 @@
         });
         wavesurfer.on('pause', function() {
           play_pause_button.find('.play').css("display", "");
+          play_pause_button.removeClass('isPlaying');
           play_pause_button.find('.pause').css("display", "none");
         });
 
@@ -120,6 +152,7 @@
         wavesurfer.load(track_name);
         wavesurfer.setVolume(volume);
       });
+
     });
   </script>
 </head>
@@ -143,7 +176,7 @@
       <div class="track-container" style="border-style:solid; border-color:gray;" id="{{pair['pairid']}}">
         <div class="player-container">
           <h3>Track A</h3>
-          <div class="waveform " track-path="{{folder_with_audio_files + pair['a_file']}}" volume={{pair['a_volume']}}></div>
+          <div class="waveform" track-path="{{folder_with_audio_files + pair['a_file']}}" volume={{pair['a_volume']}}></div>
           <button class="playPause" style="width:50px; height: 30px;">
             <span class="play">
               Play


### PR DESCRIPTION
Hi! This is my little contribution to this repository.

When I started doing annotations, realised that both audios could sound at the same time, which always had to do a few clicks to stop and hence, make the annotation process slower. I saw that there was an issue opened with this.

What I basically did is store the Wavesurfers objects by unique ID + the track path and then look for it and pause the other track.

It seems to work fine. 

Regards