### PR TITLE
Fix bug in unsure checkboxes

### DIFF
--- a/templates/arousal_and_valence.html
+++ b/templates/arousal_and_valence.html
@@ -18,12 +18,15 @@
             B
         </label>
 
+        <!-- Empty label to put the checkbox in the middle column -->
+        <label></label>
+
         <input type="checkbox" name="unsure_arousal" value="off" checked="checked" style="display:none">
+        <label for="unsure_arousal" style="color:black;">
+            <input type="checkbox" name="unsure_arousal" value="unsure_arousal">
+            I am not sure
+        </label>
     </div>
-    <label for="unsure_arousal" style="color:black;">
-        <input type="checkbox" name="unsure_arousal" value="unsure_arousal">
-        I am not sure
-    </label>
 </form>
 
 <form class="form" action="" id="form-valence-{{sound_track}}">
@@ -46,11 +49,13 @@
             B
         </label>
 
-        <input type="checkbox" name="unsure_valence" value="off" checked="checked" style="display:none">
-    </div>
+        <!-- Empty label to put the checkbox in the middle column -->
+        <label></label>
 
-    <label for="unsure_valence" style="color:black;">
-        <input type="checkbox" name="unsure_valence" value="unsure_valence">
-        I am not sure
-    </label>
+        <input type="checkbox" name="unsure_valence" value="off" checked="checked" style="display:none">
+        <label for="unsure_valence" style="color:black;">
+            <input type="checkbox" name="unsure_valence" value="unsure_valence">
+            I am not sure
+        </label>
+    </div>
 </form>


### PR DESCRIPTION
The layout change from https://github.com/MTG/mtg-arousal-valence-annotator/commit/060c2686a6c0e72936bbfe294caf5f69fcfc1e30 introduced a bug in which `unsure_arousal` and `unsure_valence` were always set to off.
This commit fixes it by putting the respective checkboxes under the `box` class so that the values are retrieved with the rest of the form.